### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,11 @@
+##############################################################
+#
+# List of approvers/reviewers for Skyfarer-Academy/web-template
+#
+##############################################################
+#
+#  https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+
+# These owners will be the default owners for everything in the repo, and automatically asked for review. 
+*       @alexwitherspoon @gpavlov2016


### PR DESCRIPTION
Creating a CODEOWNERS to help with automation for reviews and approvals since we have multiple engineers working in the codebase. It's a quality of life change. Right now, defaulting to code reviews requiring Guy or Alex. Guy and Alex have rights to force a merge in case we need to, or don't have access to more approvals.


Documentation & Readme here: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners