### PR TITLE
Merge to dev and main: Custom listing commission

### DIFF
--- a/server/api/initiate-privileged.js
+++ b/server/api/initiate-privileged.js
@@ -35,7 +35,7 @@ module.exports = (req, res) => {
       lineItems = await transactionLineItems(
         listing,
         { ...orderData, ...bodyParams.params },
-        extractOverridingProviderCommissionPercent(showListingResponse, providerCommission),
+        extractOverridingProviderCommissionPercent(showListingResponse, providerCommission, listing?.attributes?.publicData?.listingType),
         extractOverridingCustomerCommissionPercent(userDataResponse, customerCommission, listing?.attributes?.publicData?.listingType)
       );
 

--- a/server/api/transaction-line-items.js
+++ b/server/api/transaction-line-items.js
@@ -29,7 +29,7 @@ module.exports = (req, res) => {
       const lineItems = await transactionLineItems(
         listing,
         orderData,
-        extractOverridingProviderCommissionPercent(showListingResponse, providerCommission),
+        extractOverridingProviderCommissionPercent(showListingResponse, providerCommission, listing?.attributes?.publicData?.listingType),
         extractOverridingCustomerCommissionPercent(userDataResponse, customerCommission, listing?.attributes?.publicData?.listingType)
       );
 

--- a/server/api/transition-privileged.js
+++ b/server/api/transition-privileged.js
@@ -34,7 +34,7 @@ module.exports = (req, res) => {
       lineItems = await transactionLineItems(
         listing,
         { ...orderData, ...bodyParams.params },
-        extractOverridingProviderCommissionPercent(showListingResponse, providerCommission),
+        extractOverridingProviderCommissionPercent(showListingResponse, providerCommission, listing?.attributes?.publicData?.listingType),
         extractOverridingCustomerCommissionPercent(userDataResponse, customerCommission, listing?.attributes?.publicData?.listingType)
       );
 

--- a/server/api/util/commission-override.js
+++ b/server/api/util/commission-override.js
@@ -1,8 +1,16 @@
+
 const extractOverridingProviderCommissionPercent = (authorJoinedListing, globalProviderCommission) => {
+  const listingAttributes = authorJoinedListing.data.data?.attributes;
+  const listingPublicData = listingAttributes?.publicData;
+
+  console.log("Listing Attributes:", listingAttributes);
+  console.log("Listing PublicData:", listingPublicData);
+  console.log("Listing Type (publicData.listingType):", listingPublicData?.listingType)
   let overrideProviderCommissionPercent =
     Array.isArray(authorJoinedListing.data.included) && authorJoinedListing.data.included[0]?.attributes?.profile?.metadata?.provider_commission_percentage != null
       ? authorJoinedListing.data.included[0].attributes.profile.metadata.provider_commission_percentage
       : null;
+  console.log("Listing data is: ", authorJoinedListing.data.included);
 
   const overrideValueIsANumber = typeof overrideProviderCommissionPercent === 'number';
 

--- a/server/api/util/commission-override.js
+++ b/server/api/util/commission-override.js
@@ -1,5 +1,5 @@
 // Custom commission mapping by listing type
-//Customer commission is set to be 0% and the provider commission are given values
+// Customer commission is set to be 0% and the provider commission values are specified
 const listingTypeCommissionMap = {
   'in-person': { provider: 5, customer: 0 },
   'in-person-school': { provider: 0, customer: 0 },
@@ -9,14 +9,8 @@ const listingTypeCommissionMap = {
   'Full-Course-Live-Online': { provider: 10, customer: 0 },
 };
 
-const extractOverridingProviderCommissionPercent = (authorJoinedListing, globalProviderCommission) => {
-  const listingAttributes = authorJoinedListing.data.data?.attributes;
-  const listingPublicData = listingAttributes?.publicData;
-
-  console.log("Listing Attributes:", listingAttributes);
-  console.log("Listing PublicData:", listingPublicData);
-  console.log("Listing Type (publicData.listingType):", listingType);
-
+// ✅ Updated to include listingType as a parameter
+const extractOverridingProviderCommissionPercent = (authorJoinedListing, globalProviderCommission, listingType) => {
   // Check for custom commission based on listingType
   const customCommission = listingTypeCommissionMap[listingType];
   if (customCommission?.provider != null) {
@@ -26,16 +20,18 @@ const extractOverridingProviderCommissionPercent = (authorJoinedListing, globalP
 
   // Check for user override from metadata
   let overrideProviderCommissionPercent =
-    Array.isArray(authorJoinedListing.data.included) && authorJoinedListing.data.included[0]?.attributes?.profile?.metadata?.provider_commission_percentage != null
+    Array.isArray(authorJoinedListing.data.included) &&
+    authorJoinedListing.data.included[0]?.attributes?.profile?.metadata?.provider_commission_percentage != null
       ? authorJoinedListing.data.included[0].attributes.profile.metadata.provider_commission_percentage
       : null;
+
   console.log("Listing data is: ", authorJoinedListing.data.included);
 
   const overrideValueIsANumber = typeof overrideProviderCommissionPercent === 'number';
 
   if (typeof overrideProviderCommissionPercent === "object" &&
-    overrideProviderCommissionPercent !== null &&
-    Object.keys(overrideProviderCommissionPercent).length === 0) {
+      overrideProviderCommissionPercent !== null &&
+      Object.keys(overrideProviderCommissionPercent).length === 0) {
     overrideProviderCommissionPercent = null;
   }
 
@@ -48,6 +44,7 @@ const extractOverridingProviderCommissionPercent = (authorJoinedListing, globalP
     : globalProviderCommission;
 };
 
+// This is already good and clean ✅
 const extractOverridingCustomerCommissionPercent = (currentUserData, globalCustomerCommission, listingType) => {
   let overrideCustomerCommissionPercent = null;
 
@@ -68,8 +65,8 @@ const extractOverridingCustomerCommissionPercent = (currentUserData, globalCusto
   const overrideValueIsANumber = typeof overrideCustomerCommissionPercent === 'number';
 
   if (typeof overrideCustomerCommissionPercent === "object" &&
-    overrideCustomerCommissionPercent !== null &&
-    Object.keys(overrideCustomerCommissionPercent).length === 0) {
+      overrideCustomerCommissionPercent !== null &&
+      Object.keys(overrideCustomerCommissionPercent).length === 0) {
     overrideCustomerCommissionPercent = null;
   }
 

--- a/src/components/OrderPanel/ProductOrderForm/ProductOrderForm.js
+++ b/src/components/OrderPanel/ProductOrderForm/ProductOrderForm.js
@@ -7,6 +7,8 @@ import { Form as FinalForm, FormSpy } from 'react-final-form';
 // import { VoucherifyValidate } from '@voucherify/react-widget';
 import { VoucherifyValidate } from '@mathiscode/voucherify-react-widget';
 
+import Logo from '../../../assets/logo-icon.png';
+
 import { FormattedMessage, useIntl } from '../../../util/reactIntl';
 import { propTypes } from '../../../util/types';
 import { numberAtLeast, required } from '../../../util/validators';

--- a/src/containers/SearchPage/SearchPage.duck.js
+++ b/src/containers/SearchPage/SearchPage.duck.js
@@ -265,6 +265,16 @@ export const searchListings = (searchParams, config) => (dispatch, getState, sdk
   return sdk.listings
     .query(params)
     .then(response => {
+      
+      const listingsSummary = response.data.data.map(listing => {
+        return {
+          id: listing.id.uuid, // or listing.id if you prefer the full ID object
+          listingType: listing.attributes.publicData.listingType,
+        };
+      });
+      
+      console.log(listingsSummary); 
+      
       const listingFields = config?.listing?.listingFields;
       const sanitizeConfig = { listingFields };
 


### PR DESCRIPTION
I changed the listing types according to the listing types defined in the Sharetribe console (main). The code workf fine for this functionality.
I created a new listing which is of type: Online which has Provider commission to be 10%. And from a student account placed the order. These are some screenshots to support the task

![Screenshot (109)](https://github.com/user-attachments/assets/cc426e77-bdd4-4219-b50a-bfda4e6237ff)
![Screenshot (110)](https://github.com/user-attachments/assets/ba60289e-d2c7-424a-a9de-4990bf68c73a)
![Screenshot (111)](https://github.com/user-attachments/assets/5f94e48e-cb3e-410d-98da-24550f86fcbe)

**If this is approved for dev, we can just merge it with main as well, because I have made sure that the listing types in dev and main are same through the Sharetribe console

Note: For Future use, if we want to change the commission, we just need to edit the values in commission-override.js file.**