### PR TITLE
TOS Acceptance flow and reset password

### DIFF
--- a/src/containers/AuthenticationPage/AuthenticationPage.js
+++ b/src/containers/AuthenticationPage/AuthenticationPage.js
@@ -200,7 +200,7 @@ export const AuthenticationForms = props => {
     },
   ];
 
-  const handleSubmitSignup = async values => {
+const handleSubmitSignup = async values => {
   const { userType, email, password, fname, lname, displayName, ...rest } = values;
   const displayNameMaybe = displayName ? { displayName: displayName.trim() } : {};
 
@@ -225,11 +225,11 @@ export const AuthenticationForms = props => {
     ...displayNameMaybe,
     publicData: {
       userType,
-      signupTimestamp, // visible publicly
       ...pickUserFieldsData(rest, 'public', userType, userFields),
     },
     protectedData: {
       signupIP, // internal use only
+      signupTimestamp, // visible publicly
       ...pickUserFieldsData(rest, 'protected', userType, userFields),
       ...getNonUserFieldParams(rest, userFields),
     },

--- a/src/containers/AuthenticationPage/TermsAndConditions/TermsAndConditions.js
+++ b/src/containers/AuthenticationPage/TermsAndConditions/TermsAndConditions.js
@@ -7,7 +7,7 @@ import { FormattedMessage, intlShape } from '../../../util/reactIntl';
 
 import css from './TermsAndConditions.module.css';
 
-const KEY_CODE_ENTER = 13;
+const KEY_CODE_ENTER = 13; 
 
 /**
  * A component that renders the terms and conditions.

--- a/src/containers/AuthenticationPage/TermsAndConditions/TermsAndConditions.module.css
+++ b/src/containers/AuthenticationPage/TermsAndConditions/TermsAndConditions.module.css
@@ -18,11 +18,12 @@
 .privacyLink,
 .termsLink {
   composes: marketplaceModalHelperLink from global;
-  color: var(--marketplaceColor);
+  color: var(--marketplaceColorLight);
+  text-decoration: underline;
+  cursor: pointer;
 
   &:hover {
     color: var(--marketplaceColorDark);
-    text-decoration: underline;
-    cursor: pointer;
+    /* text-decoration: underline; */
   }
 }

--- a/src/containers/PasswordRecoveryPage/PasswordRecoveryForm/PasswordRecoveryForm.js
+++ b/src/containers/PasswordRecoveryPage/PasswordRecoveryForm/PasswordRecoveryForm.js
@@ -117,7 +117,7 @@ class PasswordRecoveryForm extends Component {
               <div className={css.bottomWrapper}>
                 <p className={css.bottomWrapperText}>
                   <span className={css.modalHelperText}>
-                    {termsAndConditions}  
+                    {/* {termsAndConditions}   */}
                     <FormattedMessage
                       id="PasswordRecoveryForm.loginLinkInfo"
                       values={{ loginLink }}

--- a/src/containers/PasswordRecoveryPage/PasswordRecoveryForm/PasswordRecoveryForm.js
+++ b/src/containers/PasswordRecoveryPage/PasswordRecoveryForm/PasswordRecoveryForm.js
@@ -117,19 +117,17 @@ class PasswordRecoveryForm extends Component {
               <div className={css.bottomWrapper}>
                 <p className={css.bottomWrapperText}>
                   <span className={css.modalHelperText}>
+                    {termsAndConditions}  
                     <FormattedMessage
                       id="PasswordRecoveryForm.loginLinkInfo"
                       values={{ loginLink }}
                     />
                   </span>
                 </p>
-
-                <div className={css.bottomWrapper}>
-                  {termsAndConditions}
-                  <PrimaryButton type="submit" inProgress={submitInProgress} disabled={submitDisabled}>
-                    <FormattedMessage id="PasswordRecoveryForm.sendInstructions" />
-                  </PrimaryButton>
-                </div>
+                {/* {termsAndConditions} */}
+                <PrimaryButton type="submit" inProgress={submitInProgress} disabled={submitDisabled}>
+                  <FormattedMessage id="PasswordRecoveryForm.sendInstructions" />
+                </PrimaryButton>      
               </div>
             </Form>
           );

--- a/src/containers/PasswordRecoveryPage/PasswordRecoveryForm/PasswordRecoveryForm.js
+++ b/src/containers/PasswordRecoveryPage/PasswordRecoveryForm/PasswordRecoveryForm.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
+import TermsAndConditions from '../../AuthenticationPage/TermsAndConditions/TermsAndConditions';
 import { Form as FinalForm } from 'react-final-form';
+import arrayMutators from 'final-form-arrays';
 import isEqual from 'lodash/isEqual';
 import classNames from 'classnames';
 
@@ -34,17 +36,20 @@ class PasswordRecoveryForm extends Component {
     return (
       <FinalForm
         {...this.props}
+        mutators={{ ...arrayMutators }}
         render={fieldRenderProps => {
           const {
             rootClassName,
             className,
             formId,
             handleSubmit,
-            pristine,
+            // pristine,
+            termsAndConditions,
             initialValues,
             inProgress = false,
             recoveryError,
             values,
+            invalid,
           } = fieldRenderProps;
 
           const intl = useIntl();
@@ -80,9 +85,8 @@ class PasswordRecoveryForm extends Component {
           const classes = classNames(rootClassName || css.root, className);
           const submitInProgress = inProgress;
           const submittedOnce = Object.keys(this.submittedValues).length > 0;
-          const pristineSinceLastSubmit = submittedOnce && isEqual(values, this.submittedValues);
-          const submitDisabled =
-            (pristine && !initialEmail) || submitInProgress || pristineSinceLastSubmit;
+          // const pristineSinceLastSubmit = submittedOnce && isEqual(values, this.submittedValues);
+          const submitDisabled = invalid || submitInProgress;
 
           const loginLink = (
             <NamedLink name="LoginPage" className={css.modalHelperLink}>
@@ -120,13 +124,12 @@ class PasswordRecoveryForm extends Component {
                   </span>
                 </p>
 
-                <PrimaryButton
-                  type="submit"
-                  inProgress={submitInProgress}
-                  disabled={submitDisabled}
-                >
-                  <FormattedMessage id="PasswordRecoveryForm.sendInstructions" />
-                </PrimaryButton>
+                <div className={css.bottomWrapper}>
+                  {termsAndConditions}
+                  <PrimaryButton type="submit" inProgress={submitInProgress} disabled={submitDisabled}>
+                    <FormattedMessage id="PasswordRecoveryForm.sendInstructions" />
+                  </PrimaryButton>
+                </div>
               </div>
             </Form>
           );

--- a/src/containers/PasswordRecoveryPage/PasswordRecoveryPage.js
+++ b/src/containers/PasswordRecoveryPage/PasswordRecoveryPage.js
@@ -51,6 +51,9 @@ const PasswordRecovery = props => {
       <p className={css.modalMessage}>
         <FormattedMessage id="PasswordRecoveryPage.forgotPasswordMessage" />
       </p>
+      <p className={css.modalMessage}>
+        <FormattedMessage id="PasswordRecoveryPage.forgotPasswordNote" />
+      </p>
       <PasswordRecoveryForm
         inProgress={recoveryInProgress}
         onChange={onChange}

--- a/src/containers/PasswordRecoveryPage/PasswordRecoveryPage.js
+++ b/src/containers/PasswordRecoveryPage/PasswordRecoveryPage.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { useLocation } from 'react-router-dom';
-
+import TermsAndConditions from '../AuthenticationPage/TermsAndConditions/TermsAndConditions';
 import { useConfiguration } from '../../context/configurationContext';
 import { FormattedMessage, useIntl } from '../../util/reactIntl';
 import { propTypes } from '../../util/types';
@@ -31,7 +31,17 @@ import {
 import css from './PasswordRecoveryPage.module.css';
 
 const PasswordRecovery = props => {
-  const { initialEmail, onChange, onSubmitEmail, recoveryInProgress, recoveryError } = props;
+  const {
+    initialEmail,
+    onChange,
+    onSubmitEmail,
+    recoveryInProgress,
+    recoveryError,
+    onOpenTermsOfService,
+    onOpenPrivacyPolicy,
+    intl
+  } = props;
+
   return (
     <div className={css.submitEmailContent}>
       <IconKeys className={css.modalIcon} />
@@ -47,10 +57,19 @@ const PasswordRecovery = props => {
         onSubmit={values => onSubmitEmail(values.email)}
         initialValues={{ email: initialEmail }}
         recoveryError={recoveryError}
+        termsAndConditions={
+          <TermsAndConditions
+            formId="PasswordRecoveryForm"
+            onOpenTermsOfService={onOpenTermsOfService}
+            onOpenPrivacyPolicy={onOpenPrivacyPolicy}
+            intl={intl}
+          />
+        }
       />
     </div>
   );
 };
+
 
 const GenericError = () => {
   return (
@@ -165,6 +184,9 @@ export const PasswordRecoveryPageComponent = props => {
       onSubmitEmail={onSubmitEmail}
       recoveryInProgress={recoveryInProgress}
       recoveryError={recoveryError}
+      onOpenTermsOfService={props.onOpenTermsOfService}
+      onOpenPrivacyPolicy={props.onOpenPrivacyPolicy}
+      intl={intl}
     />
   );
 

--- a/src/containers/PasswordRecoveryPage/PasswordRecoveryPage.js
+++ b/src/containers/PasswordRecoveryPage/PasswordRecoveryPage.js
@@ -51,9 +51,6 @@ const PasswordRecovery = props => {
       <p className={css.modalMessage}>
         <FormattedMessage id="PasswordRecoveryPage.forgotPasswordMessage" />
       </p>
-      <p className={css.modalMessage}>
-        <FormattedMessage id="PasswordRecoveryPage.forgotPasswordNote" />
-      </p>
       <PasswordRecoveryForm
         inProgress={recoveryInProgress}
         onChange={onChange}

--- a/src/containers/PasswordResetPage/PasswordResetForm/PasswordResetForm.js
+++ b/src/containers/PasswordResetPage/PasswordResetForm/PasswordResetForm.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import TermsAndConditions from '../../AuthenticationPage/TermsAndConditions/TermsAndConditions';
 import { Form as FinalForm } from 'react-final-form';
 import classNames from 'classnames';
-
+import arrayMutators from 'final-form-arrays';
 import { FormattedMessage, useIntl } from '../../../util/reactIntl';
 import * as validators from '../../../util/validators';
 
@@ -22,6 +23,7 @@ import css from './PasswordResetForm.module.css';
 const PasswordResetForm = props => (
   <FinalForm
     {...props}
+    mutators={{ ...arrayMutators }}
     render={fieldRenderProps => {
       const {
         rootClassName,
@@ -30,6 +32,7 @@ const PasswordResetForm = props => (
         handleSubmit,
         inProgress = false,
         invalid,
+        termsAndConditions,
       } = fieldRenderProps;
 
       const intl = useIntl();
@@ -90,6 +93,7 @@ const PasswordResetForm = props => (
               passwordMaxLength
             )}
           />
+          {termsAndConditions}
           <PrimaryButton type="submit" inProgress={submitInProgress} disabled={submitDisabled}>
             <FormattedMessage id="PasswordResetForm.submitButtonText" />
           </PrimaryButton>

--- a/src/containers/PasswordResetPage/PasswordResetForm/PasswordResetForm.module.css
+++ b/src/containers/PasswordResetPage/PasswordResetForm/PasswordResetForm.module.css
@@ -3,5 +3,5 @@
 
 .password {
   composes: marketplaceModalPasswordMargins from global;
-  margin-bottom: 24px;
+  margin-bottom: 64px;
 }

--- a/src/containers/PasswordResetPage/PasswordResetPage.duck.js
+++ b/src/containers/PasswordResetPage/PasswordResetPage.duck.js
@@ -43,7 +43,7 @@ export const resetPasswordError = e => ({
 // NOTE: We DO NOT call update_profile here anymore (that caused 403 when user was not authenticated).
 // Instead, we stash the metadata to localStorage so auth.duck.js can update protectedData
 // immediately after a successful login.
-export const resetPassword = (email, passwordResetToken, newPassword) => (
+export const resetPassword = (email, passwordResetToken, newPassword, protectedDataUpdate) => (
   dispatch,
   getState,
   sdk
@@ -57,16 +57,16 @@ export const resetPassword = (email, passwordResetToken, newPassword) => (
     .then(() => {
       console.log('✅ Password reset successful');
 
-    //   // Stash metadata for after-login update (handled in auth.duck.js)
-    //   if (protectedDataUpdate) {
-    //     try {
-    //       localStorage.setItem('passwordResetMetadata', JSON.stringify(protectedDataUpdate));
-    //       console.log('💾 Stashed reset metadata for after-login update:', protectedDataUpdate);
-    //     } catch (err) {
-    //       console.warn('Could not save reset metadata to localStorage:', err);
-    //     }
-    //   }
-      })
+      // Stash metadata for after-login update (handled in auth.duck.js)
+      if (protectedDataUpdate) {
+        try {
+          localStorage.setItem('passwordResetMetadata', JSON.stringify(protectedDataUpdate));
+          console.log('💾 Stashed reset metadata for after-login update:', protectedDataUpdate);
+        } catch (err) {
+          console.warn('Could not save reset metadata to localStorage:', err);
+        }
+      }
+    })
     .then(() => dispatch(resetPasswordSuccess()))
     .catch(e => dispatch(resetPasswordError(storableError(e))));
 };

--- a/src/containers/PasswordResetPage/PasswordResetPage.duck.js
+++ b/src/containers/PasswordResetPage/PasswordResetPage.duck.js
@@ -42,15 +42,24 @@ export const resetPasswordError = e => ({
 
 // ================ Thunks ================ //
 
-export const resetPassword = (email, passwordResetToken, newPassword) => (
+export const resetPassword = (email, passwordResetToken, newPassword, protectedDataUpdate) => (
   dispatch,
   getState,
   sdk
 ) => {
   dispatch(resetPasswordRequest());
-  const params = { email, passwordResetToken, newPassword };
+
+  // Merge newPassword + protectedData into params
+  const params = {
+    email,
+    passwordResetToken,
+    newPassword,
+    protectedData: protectedDataUpdate, // <-- include metadata here
+  };
+
   return sdk.passwordReset
     .reset(params)
     .then(() => dispatch(resetPasswordSuccess()))
     .catch(e => dispatch(resetPasswordError(storableError(e))));
 };
+

--- a/src/containers/PasswordResetPage/PasswordResetPage.duck.js
+++ b/src/containers/PasswordResetPage/PasswordResetPage.duck.js
@@ -21,7 +21,7 @@ export default function reducer(state = initialState, action = {}) {
     case RESET_PASSWORD_SUCCESS:
       return { ...state, resetPasswordInProgress: false };
     case RESET_PASSWORD_ERROR:
-      console.error(payload); // eslint-disable-line no-console
+      console.error(payload);
       return { ...state, resetPasswordInProgress: false, resetPasswordError: payload };
     default:
       return state;
@@ -31,16 +31,14 @@ export default function reducer(state = initialState, action = {}) {
 // ================ Action creators ================ //
 
 export const resetPasswordRequest = () => ({ type: RESET_PASSWORD_REQUEST });
-
 export const resetPasswordSuccess = () => ({ type: RESET_PASSWORD_SUCCESS });
-
 export const resetPasswordError = e => ({
   type: RESET_PASSWORD_ERROR,
   error: true,
   payload: e,
 });
 
-// ================ Thunks ================ //
+// ================ Thunk ================ //
 
 export const resetPassword = (email, passwordResetToken, newPassword, protectedDataUpdate) => (
   dispatch,
@@ -49,17 +47,20 @@ export const resetPassword = (email, passwordResetToken, newPassword, protectedD
 ) => {
   dispatch(resetPasswordRequest());
 
-  // Merge newPassword + protectedData into params
   const params = {
     email,
     passwordResetToken,
     newPassword,
-    protectedData: protectedDataUpdate, // <-- include metadata here
+    protectedData: protectedDataUpdate, // send metadata here
   };
 
   return sdk.passwordReset
     .reset(params)
-    .then(() => dispatch(resetPasswordSuccess()))
+    .then(res => {
+      console.log('✅ Password reset completed for user:', email);
+      console.log('Metadata sent:', protectedDataUpdate);
+      dispatch(resetPasswordSuccess());
+    })
     .catch(e => dispatch(resetPasswordError(storableError(e))));
 };
 

--- a/src/containers/PasswordResetPage/PasswordResetPage.duck.js
+++ b/src/containers/PasswordResetPage/PasswordResetPage.duck.js
@@ -43,7 +43,7 @@ export const resetPasswordError = e => ({
 // NOTE: We DO NOT call update_profile here anymore (that caused 403 when user was not authenticated).
 // Instead, we stash the metadata to localStorage so auth.duck.js can update protectedData
 // immediately after a successful login.
-export const resetPassword = (email, passwordResetToken, newPassword, protectedDataUpdate) => (
+export const resetPassword = (email, passwordResetToken, newPassword) => (
   dispatch,
   getState,
   sdk
@@ -57,16 +57,16 @@ export const resetPassword = (email, passwordResetToken, newPassword, protectedD
     .then(() => {
       console.log('✅ Password reset successful');
 
-      // Stash metadata for after-login update (handled in auth.duck.js)
-      if (protectedDataUpdate) {
-        try {
-          localStorage.setItem('passwordResetMetadata', JSON.stringify(protectedDataUpdate));
-          console.log('💾 Stashed reset metadata for after-login update:', protectedDataUpdate);
-        } catch (err) {
-          console.warn('Could not save reset metadata to localStorage:', err);
-        }
-      }
-    })
+    //   // Stash metadata for after-login update (handled in auth.duck.js)
+    //   if (protectedDataUpdate) {
+    //     try {
+    //       localStorage.setItem('passwordResetMetadata', JSON.stringify(protectedDataUpdate));
+    //       console.log('💾 Stashed reset metadata for after-login update:', protectedDataUpdate);
+    //     } catch (err) {
+    //       console.warn('Could not save reset metadata to localStorage:', err);
+    //     }
+    //   }
+      })
     .then(() => dispatch(resetPasswordSuccess()))
     .catch(e => dispatch(resetPasswordError(storableError(e))));
 };

--- a/src/containers/PasswordResetPage/PasswordResetPage.js
+++ b/src/containers/PasswordResetPage/PasswordResetPage.js
@@ -128,31 +128,32 @@ export const PasswordResetPageComponent = props => {
   const isPasswordSubmitted = state.newPasswordSubmitted && !resetPasswordError;
 
   const handleSubmit = async values => {
-    const { password } = values;
-    setState({ newPasswordSubmitted: false });
+  const { password } = values;
+  setState({ newPasswordSubmitted: false });
 
-    // Collect metadata
-    const passwordResetTimestamp = new Date().toISOString();
-    let passwordResetIP = 'unknown';
-    try {
-      const res = await fetch('https://api.ipify.org?format=json');
-      const data = await res.json();
-      passwordResetIP = data.ip;
-    } catch (err) {
-      console.error('Could not fetch IP address', err);
-    }
+  // Collect metadata
+  const passwordResetTimestamp = new Date().toISOString();
+  let passwordResetIP = 'unknown';
+  try {
+    const res = await fetch('https://api.ipify.org?format=json');
+    const data = await res.json();
+    passwordResetIP = data.ip;
+  } catch (err) {
+    console.error('Could not fetch IP address', err);
+  }
 
-    const protectedDataUpdate = {
-      passwordResetTimestamp,
-      passwordResetIP,
-    };
+  // Create a new reset entry
+  const newResetEntry = { timestamp: passwordResetTimestamp, ip: passwordResetIP };
+  console.log('Password reset metadata (local test):', newResetEntry);
 
-    console.log('Password reset metadata (local test):', protectedDataUpdate);
+  // Save temporarily to localStorage for after-login update
+  localStorage.setItem('passwordResetMetadata', JSON.stringify(newResetEntry));
 
-    // Call SDK to reset password (metadata will be updated after login)
-    onSubmitPassword(email, token, password, protectedDataUpdate)
-      .then(() => setState({ newPasswordSubmitted: true }));
-  };
+  // Call SDK to reset password (metadata will be appended after login)
+  onSubmitPassword(email, token, password)
+    .then(() => setState({ newPasswordSubmitted: true }));
+};
+
 
 
   return (
@@ -206,7 +207,7 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = dispatch => ({
-  onSubmitPassword: (email, token, password, protectedDataUpdate) => dispatch(resetPassword(email, token, password, protectedDataUpdate)),
+  onSubmitPassword: (email, token, password) => dispatch(resetPassword(email, token, password)),
 });
 
 // Note: it is important that the withRouter HOC is **outside** the

--- a/src/containers/PasswordResetPage/PasswordResetPage.js
+++ b/src/containers/PasswordResetPage/PasswordResetPage.js
@@ -150,7 +150,7 @@ export const PasswordResetPageComponent = props => {
     console.log('Password reset metadata (local test):', protectedDataUpdate);
 
     // Call SDK to reset password (metadata will be updated after login)
-    onSubmitPassword(email, token, password)
+    onSubmitPassword(email, token, password, protectedDataUpdate)
       .then(() => setState({ newPasswordSubmitted: true }));
   };
 
@@ -206,7 +206,7 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = dispatch => ({
-  onSubmitPassword: (email, token, password) => dispatch(resetPassword(email, token, password)),
+  onSubmitPassword: (email, token, password, protectedDataUpdate) => dispatch(resetPassword(email, token, password, protectedDataUpdate)),
 });
 
 // Note: it is important that the withRouter HOC is **outside** the

--- a/src/containers/PasswordResetPage/PasswordResetPage.js
+++ b/src/containers/PasswordResetPage/PasswordResetPage.js
@@ -57,9 +57,20 @@ const ResetFormContent = props => {
       <Heading as="h1" rootClassName={css.modalTitle}>
         <FormattedMessage id="PasswordResetPage.mainHeading" />
       </Heading>
-      <p className={css.modalMessage}>
+      {/* <p className={css.modalMessage}>
         <FormattedMessage id="PasswordResetPage.helpText" />
+      </p> */}
+      <p className={css.modalMessage}>
+        <FormattedMessage id="PasswordResetPage.helpText1" />
       </p>
+      <ul className={css.modalMessageList}>
+        <li className={css.modalMessage}>
+          <FormattedMessage id="PasswordResetPage.helpText2" />
+        </li>
+        <li className={css.modalMessage}>
+          <FormattedMessage id="PasswordResetPage.helpText3" />
+        </li>
+      </ul>
       {resetPasswordError ? (
         <p className={css.error}>
           <FormattedMessage id="PasswordResetPage.resetFailed" />
@@ -128,32 +139,31 @@ export const PasswordResetPageComponent = props => {
   const isPasswordSubmitted = state.newPasswordSubmitted && !resetPasswordError;
 
   const handleSubmit = async values => {
-  const { password } = values;
-  setState({ newPasswordSubmitted: false });
+    const { password } = values;
+    setState({ newPasswordSubmitted: false });
 
-  // Collect metadata
-  const passwordResetTimestamp = new Date().toISOString();
-  let passwordResetIP = 'unknown';
-  try {
-    const res = await fetch('https://api.ipify.org?format=json');
-    const data = await res.json();
-    passwordResetIP = data.ip;
-  } catch (err) {
-    console.error('Could not fetch IP address', err);
-  }
+    // Collect metadata
+    const passwordResetTimestamp = new Date().toISOString();
+    let passwordResetIP = 'unknown';
+    try {
+      const res = await fetch('https://api.ipify.org?format=json');
+      const data = await res.json();
+      passwordResetIP = data.ip;
+    } catch (err) {
+      console.error('Could not fetch IP address', err);
+    }
 
-  // Create a new reset entry
-  const newResetEntry = { timestamp: passwordResetTimestamp, ip: passwordResetIP };
-  console.log('Password reset metadata (local test):', newResetEntry);
+    const protectedDataUpdate = {
+      passwordResetTimestamp,
+      passwordResetIP,
+    };
 
-  // Save temporarily to localStorage for after-login update
-  localStorage.setItem('passwordResetMetadata', JSON.stringify(newResetEntry));
+    console.log('Password reset metadata (local test):', protectedDataUpdate);
 
-  // Call SDK to reset password (metadata will be appended after login)
-  onSubmitPassword(email, token, password)
-    .then(() => setState({ newPasswordSubmitted: true }));
-};
-
+    // Call SDK to reset password (metadata will be updated after login)
+    onSubmitPassword(email, token, password, protectedDataUpdate)
+      .then(() => setState({ newPasswordSubmitted: true }));
+  };
 
 
   return (
@@ -207,7 +217,7 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = dispatch => ({
-  onSubmitPassword: (email, token, password) => dispatch(resetPassword(email, token, password)),
+  onSubmitPassword: (email, token, password, protectedDataUpdate) => dispatch(resetPassword(email, token, password, protectedDataUpdate)),
 });
 
 // Note: it is important that the withRouter HOC is **outside** the

--- a/src/containers/PasswordResetPage/PasswordResetPage.js
+++ b/src/containers/PasswordResetPage/PasswordResetPage.js
@@ -129,31 +129,29 @@ export const PasswordResetPageComponent = props => {
 
   const handleSubmit = async values => {
     const { password } = values;
-
     setState({ newPasswordSubmitted: false });
 
     // Collect metadata
     const passwordResetTimestamp = new Date().toISOString();
     let passwordResetIP = 'unknown';
-      try {
-        const res = await fetch('https://api.ipify.org?format=json'); // free IP API
-        const data = await res.json();
-        passwordResetIP = data.ip;
-      } catch (err) {
-        console.error('Could not fetch IP address', err);
-      }
+    try {
+      const res = await fetch('https://api.ipify.org?format=json');
+      const data = await res.json();
+      passwordResetIP = data.ip;
+    } catch (err) {
+      console.error('Could not fetch IP address', err);
+    }
 
-    // Include metadata in protectedData
     const protectedDataUpdate = {
       passwordResetTimestamp,
       passwordResetIP,
     };
 
-    // Call SDK to update user protectedData before submitting new password
-    onSubmitPassword(email, token, password, protectedDataUpdate)
-      .then(() => {
-        setState({ newPasswordSubmitted: true });
-      });
+    console.log('Password reset metadata (local test):', protectedDataUpdate);
+
+    // Call SDK to reset password (metadata will be updated after login)
+    onSubmitPassword(email, token, password)
+      .then(() => setState({ newPasswordSubmitted: true }));
   };
 
 
@@ -208,7 +206,7 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = dispatch => ({
-  onSubmitPassword: (email, token, password, protectedDataUpdate) => dispatch(resetPassword(email, token, password, protectedDataUpdate)),
+  onSubmitPassword: (email, token, password) => dispatch(resetPassword(email, token, password)),
 });
 
 // Note: it is important that the withRouter HOC is **outside** the

--- a/src/containers/PasswordResetPage/PasswordResetPage.js
+++ b/src/containers/PasswordResetPage/PasswordResetPage.js
@@ -1,3 +1,4 @@
+console.log("Password reset page");
 import React, { useState } from 'react';
 import { compose } from 'redux';
 import { connect } from 'react-redux';

--- a/src/containers/PasswordResetPage/PasswordResetPage.module.css
+++ b/src/containers/PasswordResetPage/PasswordResetPage.module.css
@@ -40,6 +40,11 @@
   composes: marketplaceModalParagraphStyles from global;
 }
 
+.modalMessageList {
+  padding-left: 1rem; /* indentation for bullets */
+  list-style-type: disc; /* default bullets */
+}
+
 /* Make the email pop */
 .email {
   font-weight: var(--fontWeightHighlightEmail);

--- a/src/containers/TopbarContainer/Topbar/Topbar.js
+++ b/src/containers/TopbarContainer/Topbar/Topbar.js
@@ -205,7 +205,7 @@ const TopbarComponent = props => {
     });
   };
 
-  console.log("current user-->", currentUser);
+  //console.log("current user-->", currentUser);
 
   const showCreateListingsLink = showCreateListingLinkForUser(config, currentUser);
   const { customer: isCustomer, provider: isProvider } = getCurrentUserTypeRoles(

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
@@ -203,6 +203,12 @@ const TopbarDesktop = props => {
   const addListingLinkMaybe = authenticatedOnClientSide && isInstructor(currentUser) ? (
   <AddListingButton currentUser={currentUser} />
   ) : null;
+  
+  // console.log(currentUser?.attributes?.profile?.publicData?.userType);
+  // console.log('School user:', currentUser?.attributes?.email);
+  // console.log('authenticatedOnClientSide:', authenticatedOnClientSide);
+  // console.log('isInstructor:', currentUser ? isInstructor(currentUser) : false);
+  // console.log('hasPermissionToPostListings:', currentUser ? hasPermissionToPostListings(currentUser) : false);
 
   const inboxLinkMaybe = authenticatedOnClientSide ? (
     <InboxLink notificationCount={notificationCount} inboxTab={inboxTab} />
@@ -264,5 +270,7 @@ const TopbarDesktop = props => {
     </nav>
   );
 };
+
+
 
 export default TopbarDesktop;

--- a/src/ducks/user.duck.js
+++ b/src/ducks/user.duck.js
@@ -438,4 +438,4 @@ export const sendVerificationEmail = () => (dispatch, getState, sdk) => {
     .sendVerificationEmail()
     .then(() => dispatch(sendVerificationEmailSuccess()))
     .catch(e => dispatch(sendVerificationEmailError(storableError(e))));
-};
+}; 

--- a/src/util/userHelpers.js
+++ b/src/util/userHelpers.js
@@ -1,5 +1,6 @@
 import { EXTENDED_DATA_SCHEMA_TYPES } from './types';
 import { getFieldValue } from './fieldHelpers';
+import { isInstructor } from './skyfarer';
 
 /**
  * Get the namespaced attribute key based on the specified extended data scope and attribute key
@@ -241,9 +242,8 @@ export const showCreateListingLinkForUser = (config, currentUser) => {
 
   const canPostListings = hasPermissionToPostListings(currentUser);
 
-  return accountLinksVisibility
-    ? accountLinksVisibility.postListings && canPostListings
-    : canPostListings;
+  return (accountLinksVisibility?.postListings ?? false) || canPostListings || isInstructor(currentUser);
+
 
   // return currentUser && accountLinksVisibility
   //   ? accountLinksVisibility.postListings


### PR DESCRIPTION
In this PR TOS and privacy policy check has been added to the reset password page similar to sign up page. Styling has been modified as suggested

Apart from storing the name, email, phone of user, the code also helps store the timestamp and IP address of user when he tries to sign up to our system or when he tries to reset the password for his account.
<img width="1920" height="1080" alt="Screenshot (268)" src="https://github.com/user-attachments/assets/08f2c8a0-7efd-4bbc-95ac-f51564163b6c" />

**Note:
Reset password changes might not be visible before deployment of the code, but it can be viewed locally, and the modified reset page looks something like this:**

<img width="1920" height="1080" alt="Screenshot (267)" src="https://github.com/user-attachments/assets/079ad888-4f9c-4882-9830-cc34173fb7f8" />


