### PR TITLE
Fix favorite icon bug

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -154,7 +154,9 @@
     </style>
 
     <!--!script-->
-
+    <script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.1-min.js.gz"></script>
+    <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.8.0-min.js.gz"></script>
+    <script>window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1}));window.amplitude.init('161d8ec4629293e83cd2f2b55cc5f2eb', {"autocapture":{"elementInteractions":true}});</script>
     <link rel="stylesheet" href="%PUBLIC_URL%/static/reactDates.css" /><!-- [SKYFARER] -->
   </head>
   <body>

--- a/src/components/ListingCard/ListingCard.js
+++ b/src/components/ListingCard/ListingCard.js
@@ -300,6 +300,7 @@ export const ListingCard = props => {
       params={{ id, slug }}
       target={typeof window !== 'undefined' ? window.location.hostname === 'localhost' ? undefined : '_blank' : '_blank'} // [SKYFARER]
     >
+    <div className={css.imageWrapper}>
       <ListingCardImage
         renderSizes={renderSizes}
         title={title}
@@ -312,6 +313,17 @@ export const ListingCard = props => {
         style={cardStyle}
         showListingImage={showListingImage}
       />
+      {showHeartIcon && (
+        <button
+        className={css.favoriteButton}
+        onClick={toggleFavorites}
+        aria-label={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+        >
+          <HeartIcon filled={isFavorite} />
+        </button>
+      )}
+    </div>
+    
       <div className={css.info}>
         <PriceMaybe
           price={price}

--- a/src/components/UserNav/UserNav.js
+++ b/src/components/UserNav/UserNav.js
@@ -3,7 +3,6 @@ import { FormattedMessage } from '../../util/reactIntl';
 import classNames from 'classnames';
 import { ACCOUNT_SETTINGS_PAGES } from '../../routing/routeConfiguration';
 import { LinkTabNavHorizontal } from '../../components';
-import { isInstructor } from '../../util/skyfarer';
 
 import css from './UserNav.module.css';
 
@@ -18,10 +17,10 @@ import css from './UserNav.module.css';
  * @returns {JSX.Element} User navigation component
  */
 const UserNav = props => {
-  const { className, rootClassName, currentPage, showManageListingsLink, currentUser } = props;
+  const { className, rootClassName, currentPage, showManageListingsLink } = props;
   const classes = classNames(rootClassName || css.root, className);
 
-  const manageListingsTabMaybe = isInstructor(currentUser)
+  const manageListingsTabMaybe = showManageListingsLink
     ? [
         {
           text: <FormattedMessage id="UserNav.yourListings" />,
@@ -51,7 +50,7 @@ const UserNav = props => {
         name: 'ContactDetailsPage',
       },
     },
-    {
+    {// [SKYFARER]
       text: <FormattedMessage id="UserNav.favoriteListing" />,
       selected: currentPage === 'FavoriteListingPage',
       linkProps: {

--- a/src/components/UserNav/UserNav.js
+++ b/src/components/UserNav/UserNav.js
@@ -21,7 +21,6 @@ const UserNav = props => {
   const classes = classNames(rootClassName || css.root, className);
 
   const manageListingsTabMaybe = showManageListingsLink
-  const manageListingsTabMaybe = showManageListingsLink
     ? [
         {
           text: <FormattedMessage id="UserNav.yourListings" />,

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/CustomLinksMenu.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/CustomLinksMenu.js
@@ -119,11 +119,6 @@ const CustomLinksMenu = ({
     ...createListingLinkConfigMaybe(intl, showCreateListingsLink),
     ...customLinks,
   ]);
-  const [moreLabelWidth, setMoreLabelWidth] = useState(0);
-  const [links, setLinks] = useState([
-    ...createListingLinkConfigMaybe(intl, showCreateListingsLink),
-    ...customLinks,
-  ]);
 
   const [layoutData, setLayoutData] = useState({
     priorityLinks: links,
@@ -209,7 +204,6 @@ const CustomLinksMenu = ({
   return (
     <div className={css.customLinksMenu} ref={containerRef} {...styleMaybe}>
       <PriorityLinks links={links} priorityLinks={priorityLinks} setLinks={setLinks} />
-      {mounted && hasMenuLinks ? (
       {mounted && hasMenuLinks ? (
         <LinksMenu
           id="linksMenu"

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/CustomLinksMenu.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/CustomLinksMenu.js
@@ -19,7 +19,7 @@ const createListingLinkConfigMaybe = (intl, showLink) =>
             name: 'EditListingPage',
             params: { slug: 'draft', id: draftId, type: 'new', tab: 'details' },
           },
-          highlight: true,
+          highlight: false,
         },
       ]
     : [];

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/PriorityLinks.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/PriorityLinks.js
@@ -77,11 +77,7 @@ const PriorityLinks = props => {
         cumulatedWidth = cumulatedWidth + width;
         return [...links, { ...l, width, cumulatedWidth }];
       }, []);
-
-      let finalLinks = linksWithWidths; // [SKYFARER]
-      if (!props.isInstructor) finalLinks = linksWithWidths.filter(link => link.route?.name !== 'EditListingPage'); // [SKYFARER]
-
-      props.setLinks(finalLinks); // [SKYFARER]
+      props.setLinks(linksWithWidths);
     }
   }, [containerRef]);
 

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
@@ -22,7 +22,6 @@ import css from './TopbarDesktop.module.css';
 const SignupLink = () => {
   return (
     <NamedLink name="SignupPage" className={css.topbarLink}>
-    <NamedLink name="SignupPage" className={css.topbarLink}>
       <span className={css.topbarLinkLabel}>
         <FormattedMessage id="TopbarDesktop.signup" />
       </span>
@@ -65,7 +64,6 @@ const ProfileMenu = ({ currentPage, currentUser, onLogout, showManageListingsLin
         <Avatar className={css.avatar} user={currentUser} disableProfileLink />
       </MenuLabel>
       <MenuContent className={css.profileMenuContent}>
-        {showManageListingsLink ? (
         {showManageListingsLink ? (
           <MenuItem key="ManageListingsPage">
             <NamedLink
@@ -213,7 +211,6 @@ const TopbarDesktop = props => {
         intl={intl}
         hasClientSideContentReady={authenticatedOnClientSide || !isAuthenticatedOrJustHydrated}
         showCreateListingsLink={showCreateListingsLink}
-      />
       />
 
       {inboxLinkMaybe}

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
@@ -1,14 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import classNames from 'classnames';
 
-import { FormattedMessage, intlShape } from '../../../../util/reactIntl';
-import { isInstructor } from '../../../../util/skyfarer';
-import { hasPermissionToPostListings } from '../../../../util/userHelpers';
+import { FormattedMessage } from '../../../../util/reactIntl';
+import { ACCOUNT_SETTINGS_PAGES } from '../../../../routing/routeConfiguration';
 
-import {
-  ACCOUNT_SETTINGS_PAGES
-} from '../../../../routing/routeConfiguration';
-import { propTypes } from '../../../../util/types';
 import {
   Avatar,
   InlineTextButton,
@@ -25,29 +20,12 @@ import TopbarSearchForm from '../TopbarSearchForm/TopbarSearchForm';
 import CustomLinksMenu from './CustomLinksMenu/CustomLinksMenu';
 
 import css from './TopbarDesktop.module.css';
-import SparklyBackground from '../../../../assets/sparkly-background.jpg'; // [SKYFARER]
-
-const isLowerEnv = process.env.REACT_APP_IS_LOWER_ENV === 'true'; // [SKYFARER]
-
-// [SKYFARER]
-const InstructorMatchingButtonLink = () => {
-  return (
-    <div className={css.topbarButtonWrapper}>
-      <NamedLink name='AIMatchingPage'>
-        <PrimaryButtonInline style={{backgroundImage: `url(${SparklyBackground})`, backgroundPosition: '50% 35%'}}>
-          <FormattedMessage style={{all: "unset"}} id='TopbarDesktop.ai'/>
-        </PrimaryButtonInline>
-      </NamedLink>
-    </div>
-  );
-};
-// [/SKYFARER]
 
 const SignupLink = () => {
   return (
-    <NamedLink name='SignupPage' className={css.topbarLink}>
+    <NamedLink name="SignupPage" className={css.topbarLink}>
       <span className={css.topbarLinkLabel}>
-        <FormattedMessage id='TopbarDesktop.signup' />
+        <FormattedMessage id="TopbarDesktop.signup" />
       </span>
     </NamedLink>
   );
@@ -58,20 +36,6 @@ const LoginLink = () => {
     <NamedLink name="LoginPage" className={css.topbarLink}>
       <span className={css.topbarLinkLabel}>
         <FormattedMessage id="TopbarDesktop.login" />
-      </span>
-    </NamedLink>
-  );
-};
-
-const AddListingButton = ({ currentUser }) => {
-  if (!currentUser || !hasPermissionToPostListings(currentUser)) 
-    {
-    return null;
-  }
-  return (
-      <NamedLink name="NewListingPage" className={css.topbarLink} >
-      <span className={css.topbarLinkLabel}>
-        <FormattedMessage id="TopbarDesktop.createListing" defaultMessage="Add a new Listing" />
       </span>
     </NamedLink>
   );
@@ -102,7 +66,7 @@ const ProfileMenu = ({ currentPage, currentUser, onLogout, showManageListingsLin
         <Avatar className={css.avatar} user={currentUser} disableProfileLink />
       </MenuLabel>
       <MenuContent className={css.profileMenuContent}>
-        {showManageListingsLink && isInstructor(currentUser) ? (
+        {showManageListingsLink ? (
           <MenuItem key="ManageListingsPage">
             <NamedLink
               className={classNames(css.menuLink, currentPageClass('ManageListingsPage'))}
@@ -114,7 +78,7 @@ const ProfileMenu = ({ currentPage, currentUser, onLogout, showManageListingsLin
           </MenuItem>
         ) : null}
         <MenuItem key="ProfileSettingsPage">
-          <NamedLink
+          <NamedLink // [SKYFARER]
             className={classNames(css.menuLink, currentPageClass('FavoriteListingPage'))}
             name="FavoriteListingPage"
           >
@@ -201,22 +165,6 @@ const TopbarDesktop = props => {
   const giveSpaceForSearch = customLinks == null || customLinks?.length === 0;
   const classes = classNames(rootClassName || css.root, className);
 
-  // [SKYFARER]
-  // const instructorMatchingButtonLinkMaybe = isAuthenticated && isLowerEnv ? ( // todo remove env flag once validated
-  //   <InstructorMatchingButtonLink/>
-  // ) : null;
-  const instructorMatchingButtonLinkMaybe = null;
-  
-  const addListingLinkMaybe = authenticatedOnClientSide && isInstructor(currentUser) ? (
-  <AddListingButton currentUser={currentUser} />
-  ) : null;
-  
-  // console.log(currentUser?.attributes?.profile?.publicData?.userType);
-  // console.log('School user:', currentUser?.attributes?.email);
-  // console.log('authenticatedOnClientSide:', authenticatedOnClientSide);
-  // console.log('isInstructor:', currentUser ? isInstructor(currentUser) : false);
-  // console.log('hasPermissionToPostListings:', currentUser ? hasPermissionToPostListings(currentUser) : false);
-
   const inboxLinkMaybe = authenticatedOnClientSide ? (
     <InboxLink notificationCount={notificationCount} inboxTab={inboxTab} />
   ) : null;
@@ -258,7 +206,6 @@ const TopbarDesktop = props => {
         linkToExternalSite={config?.topbar?.logoLink}
       />
       {searchFormMaybe}
-      {addListingLinkMaybe}
 
       <CustomLinksMenu
         currentPage={currentPage}
@@ -267,9 +214,8 @@ const TopbarDesktop = props => {
         intl={intl}
         hasClientSideContentReady={authenticatedOnClientSide || !isAuthenticatedOrJustHydrated}
         showCreateListingsLink={showCreateListingsLink}
-        />
+      />
 
-      {instructorMatchingButtonLinkMaybe}{/* [SKYFARER] */}
       {inboxLinkMaybe}
       {profileMenuMaybe}
       {signupLinkMaybe}
@@ -277,7 +223,5 @@ const TopbarDesktop = props => {
     </nav>
   );
 };
-
-
 
 export default TopbarDesktop;

--- a/src/containers/TopbarContainer/Topbar/TopbarMobileMenu/TopbarMobileMenu.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarMobileMenu/TopbarMobileMenu.js
@@ -8,7 +8,6 @@ import classNames from 'classnames';
 import { ACCOUNT_SETTINGS_PAGES } from '../../../../routing/routeConfiguration';
 import { FormattedMessage } from '../../../../util/reactIntl';
 import { ensureCurrentUser } from '../../../../util/data';
-import { isInstructor } from '../../../../util/skyfarer';
 
 import {
   AvatarLarge,
@@ -16,18 +15,12 @@ import {
   InlineTextButton,
   NamedLink,
   NotificationBadge,
-  PrimaryButtonInline, // [SKYFARER]
 } from '../../../../components';
 
 import css from './TopbarMobileMenu.module.css';
 
-import SparklyBackground from '../../../../assets/sparkly-background.jpg'; // [SKYFARER]
-
-const isLowerEnv = process.env.REACT_APP_IS_LOWER_ENV === 'true'; // [SKYFARER]
-
-const CustomLinkComponent = ({ linkConfig, currentPage, currentUser }) => { // [SKYFARER MERGE: +currentUser]
+const CustomLinkComponent = ({ linkConfig, currentPage }) => {
   const { group, text, type, href, route } = linkConfig;
-
   const getCurrentPageClass = page => {
     const hasPageName = name => currentPage?.indexOf(name) === 0;
     const isCMSPage = pageId => hasPageName('CMSPage') && currentPage === `${page}:${pageId}`;
@@ -98,13 +91,11 @@ const TopbarMobileMenu = props => {
     );
   });
 
-  const createListingsLinkMaybe =
-  currentUser && isInstructor(currentUser) ? (
+  const createListingsLinkMaybe = showCreateListingsLink ? (
     <NamedLink className={css.createNewListingLink} name="NewListingPage">
       <FormattedMessage id="TopbarMobileMenu.newListingLink" />
     </NamedLink>
   ) : null;
-
 
   if (!isAuthenticated) {
     const signup = (
@@ -165,18 +156,6 @@ const TopbarMobileMenu = props => {
     </NamedLink>
   ) : null;
 
-  const InstructorMatchingButtonLink = () => { // [SKYFARER]
-    return (
-      <div className={css.topbarButtonWrapper}>
-        <NamedLink name='AIMatchingPage'>
-          <PrimaryButtonInline style={{backgroundImage: `url(${SparklyBackground})`, backgroundPosition: '50% 35%'}}>
-            <FormattedMessage style={{all: "unset"}} id='TopbarDesktop.ai'/>
-          </PrimaryButtonInline>
-        </NamedLink>
-      </div>
-    );
-  };
-
   return (
     <div className={css.root}>
       <AvatarLarge className={css.avatar} user={currentUser} />
@@ -204,7 +183,7 @@ const TopbarMobileMenu = props => {
           >
             <FormattedMessage id="TopbarMobileMenu.profileSettingsLink" />
           </NamedLink>
-          <NamedLink
+          <NamedLink // [SKYFARER]
             className={classNames(css.navigationLink, currentPageClass('FavoriteListingPage'))}
             name="FavoriteListingPage"
           >
@@ -216,9 +195,6 @@ const TopbarMobileMenu = props => {
           >
             <FormattedMessage id="TopbarMobileMenu.accountSettingsLink" />
           </NamedLink>
-          {
-            // isAuthenticated && isLowerEnv && <InstructorMatchingButtonLink/>
-          }
         </div>
         <div className={css.customLinksWrapper}>{extraLinks}</div>
         <div className={css.spacer} />

--- a/src/util/userHelpers.js
+++ b/src/util/userHelpers.js
@@ -1,6 +1,5 @@
 import { EXTENDED_DATA_SCHEMA_TYPES } from './types';
 import { getFieldValue } from './fieldHelpers';
-import { isInstructor } from './skyfarer';
 
 /**
  * Get the namespaced attribute key based on the specified extended data scope and attribute key
@@ -218,7 +217,8 @@ export const isUserSubscribed = currentUser => currentUser?.attributes?.profile?
 const getCurrentUserTypeConfig = (config, currentUser) => {
   const { userTypes } = config.user;
   return userTypes.find(
-    ut => ut.userType === currentUser?.attributes?.profile?.publicData?.userType
+    // [SKYFARER] convert to lowercase to avoid case sensitivity (old IDs were mixed-case)
+    ut => ut.userType.toLowerCase() === currentUser?.attributes?.profile?.publicData?.userType.toLowerCase()  
   );
 };
 
@@ -230,28 +230,19 @@ const getCurrentUserTypeConfig = (config, currentUser) => {
  * @returns {Boolean} true if the currentUser's user type, or the anonymous user configuration, is set to see the link
  */
 export const showCreateListingLinkForUser = (config, currentUser) => {
-  if (!currentUser) {
-    // Not logged in → fall back to config
-    return config?.topbar?.postListingsLink?.showToUnauthenticatedUsers || false;
-  }
-  
-  // const { topbar } = config;
+    
+  const { topbar } = config;
   const currentUserTypeConfig = getCurrentUserTypeConfig(config, currentUser);
 
   const { accountLinksVisibility } = currentUserTypeConfig || {};
 
-  const canPostListings = hasPermissionToPostListings(currentUser);
-
-  return (accountLinksVisibility?.postListings ?? false) || canPostListings || isInstructor(currentUser);
-
-
-  // return currentUser && accountLinksVisibility
-  //   ? accountLinksVisibility.postListings
-  //   : currentUser
-  //   ? true
-  //   : topbar?.postListingsLink
-  //   ? topbar.postListingsLink.showToUnauthenticatedUsers
-  //   : true;
+  return currentUser && accountLinksVisibility
+    ? accountLinksVisibility.postListings
+    : currentUser
+    ? true
+    : topbar?.postListingsLink
+    ? topbar.postListingsLink.showToUnauthenticatedUsers
+    : true;
 };
 
 /**


### PR DESCRIPTION
After Sharetribe release 8.7.0 Favorite icons were removed from the listing cards. This happened as the code to render these icons was not retrieved after the merge.

I have added the code back. 
Also added links in our index.html to set up Amplitude as per Nick's request.
<img width="1920" height="1080" alt="Screenshot (427)" src="https://github.com/user-attachments/assets/df5e3bec-ed0b-42db-b483-fdb35f582602" />

Some files were changed with minor modifications to solve merge conflicts with the previous PR #69 